### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Penguin classification pipeline with KFP SDK. To try to run this pipeline, check
 
 - TBD
 
-## Fetaure Works
+## Future Works
 
 ### KFP SDK
 


### PR DESCRIPTION
`Future work` may be more appropriate?
I often see `future work` in some research papers, but `future works` not so much.
ref: https://okamoto7.hatenablog.com/entry/20120217/p1 (Japanese article)