### PR TITLE
add shebang to the shell script file.

### DIFF
--- a/kfp/deploy_all_component.sh
+++ b/kfp/deploy_all_component.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 GCP_PROJECT_ID=your-sample-pipeline-project # Enter your GCP Project ID
 GCP_GCR_ENDPOINT=us.gcr.io # Enter your GCR endpoint like `asia.gcr.io`
 


### PR DESCRIPTION
`kfp/deploy_all_component.sh` is a shell script file but it lacks the shebang so it can't execute on Linux.

This PR fixes this issue with adding shebang into the file.