### PR TITLE
Replace GCPPath to GCSPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Two simple sample pipelines are introduced on this repo with both KFP SDK and TF
 <img src="kfp/dataflow.png" height=600>
 
 Penguin classification pipeline with KFP SDK. To try to run this pipeline, check [this document](kfp/).
+
 ## TFX SDK
 
 - TBD
@@ -16,7 +17,7 @@ Penguin classification pipeline with KFP SDK. To try to run this pipeline, check
 ### KFP SDK
 
 - [ ] Add unit test
-- [ ] Migrate from `GCPPath` into `Artifact`
+- [ ] Migrate from `GCSPath` into `Artifact`
 - [ ] Pipeline E2E test
 - [ ] Add Pusher component
 

--- a/kfp/components/data_generator/data_generator.yaml
+++ b/kfp/components/data_generator/data_generator.yaml
@@ -1,7 +1,7 @@
 name: data_generator
 outputs:
-- {name: train_data_path, type: {GCPPath: {data_type: CSV}}}
-- {name: eval_data_path, type: {GCPPath: {data_type: CSV}}}
+- {name: train_data_path, type: {GCSPath: {data_type: CSV}}}
+- {name: eval_data_path, type: {GCSPath: {data_type: CSV}}}
 implementation:
   container:
     image: ${tagged_name}

--- a/kfp/components/evaluator/evaluator.yaml
+++ b/kfp/components/evaluator/evaluator.yaml
@@ -1,10 +1,10 @@
 name: evaluator
 inputs:
-- {name: trained_model_path, type: {GCPPath: {data_type: PKL}}}
-- {name: transformed_eval_data_path, type: {GCPPath: {data_type: CSV}}}
+- {name: trained_model_path, type: {GCSPath: {data_type: PKL}}}
+- {name: transformed_eval_data_path, type: {GCSPath: {data_type: CSV}}}
 - {name: suffix, type: String}
 outputs:
-- {name: confusion_matrix_path, type: {GCPPath: {data_type: PNG}}}
+- {name: confusion_matrix_path, type: {GCSPath: {data_type: PNG}}}
 - {name: mlpipeline_metrics, type: Metrics}
 implementation:
   container:

--- a/kfp/components/trainer/trainer.yaml
+++ b/kfp/components/trainer/trainer.yaml
@@ -1,9 +1,9 @@
 name: trainer
 inputs:
-- {name: transformed_train_data_path, type: {GCPPath: {data_type: CSV}}}
+- {name: transformed_train_data_path, type: {GCSPath: {data_type: CSV}}}
 - {name: suffix, type: String}
 outputs:
-- {name: trained_model_path, type: {GCPPath: {data_type: PKL}}}
+- {name: trained_model_path, type: {GCSPath: {data_type: PKL}}}
 implementation:
   container:
     image: ${tagged_name}

--- a/kfp/components/transform/transform.yaml
+++ b/kfp/components/transform/transform.yaml
@@ -1,11 +1,11 @@
 name: transform
 inputs:
-- {name: train_data_path, type: {GCPPath: {data_type: CSV}}}
-- {name: eval_data_path, type: {GCPPath: {data_type: CSV}}}
+- {name: train_data_path, type: {GCSPath: {data_type: CSV}}}
+- {name: eval_data_path, type: {GCSPath: {data_type: CSV}}}
 - {name: suffix, type: String}
 outputs:
-- {name: transformed_train_data_path, type: {GCPPath: {data_type: CSV}}}
-- {name: transformed_eval_data_path, type: {GCPPath: {data_type: CSV}}}
+- {name: transformed_train_data_path, type: {GCSPath: {data_type: CSV}}}
+- {name: transformed_eval_data_path, type: {GCSPath: {data_type: CSV}}}
 implementation:
   container:
     image: ${tagged_name}


### PR DESCRIPTION
Hello.

While there is not much sample code for Vertex Pipeline, this repository has a lot of knowledge and is helpful! thanks!

BTW, `GCPPath` is not found in `kfp.dsl.types`. It looks like `GCSPath` is correct in the latest `kfp` code. I replaced it. If you like, merge please.

- https://github.com/kubeflow/pipelines/blob/74c7773ca40decfd0d4ed40dc93a6af591bbc190/sdk/python/kfp/dsl/types.py#L76-L82